### PR TITLE
Add DuckDB MCP extension example

### DIFF
--- a/examples/duckdb-mcp/README.md
+++ b/examples/duckdb-mcp/README.md
@@ -1,0 +1,28 @@
+# DuckDB MCP Server
+
+This example shows how to expose a [DuckDB](https://duckdb.org) database through the Model Context Protocol (MCP). It provides a simple `query` tool that executes SQL against a DuckDB database file and returns the results.
+
+## Running with MCP Inspector
+
+1. Install dependencies in a virtual environment:
+   ```bash
+   uv sync
+   ```
+2. Activate your environment:
+   ```bash
+   source .venv/bin/activate
+   ```
+3. Start the server in development mode:
+   ```bash
+   mcp dev src/duckdb_mcp/server.py
+   ```
+4. Open `http://localhost:5173` to access the MCP Inspector and test the `query` tool.
+
+## Using the CLI
+
+Install the project locally and invoke the CLI binary:
+
+```bash
+uv pip install .
+duckdb-mcp --help
+```

--- a/examples/duckdb-mcp/pyproject.toml
+++ b/examples/duckdb-mcp/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "duckdb-mcp"
+version = "0.1.0"
+description = "MCP Server for DuckDB queries"
+readme = "README.md"
+requires-python = ">=3.13"
+dependencies = [
+    "duckdb>=0.10.2",
+    "mcp[cli]>=1.2.0",
+]
+
+[project.scripts]
+duckdb-mcp = "duckdb_mcp:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/examples/duckdb-mcp/src/duckdb_mcp/__init__.py
+++ b/examples/duckdb-mcp/src/duckdb_mcp/__init__.py
@@ -1,0 +1,21 @@
+import argparse
+import os
+from .server import create_server
+
+
+def main() -> None:
+    """DuckDB MCP server entry point."""
+    parser = argparse.ArgumentParser(description="Expose DuckDB queries via MCP.")
+    parser.add_argument(
+        "--database",
+        default=os.environ.get("DUCKDB_PATH", ":memory:"),
+        help="Path to DuckDB database file (default: in-memory)",
+    )
+    args = parser.parse_args()
+
+    mcp = create_server(args.database)
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/duckdb-mcp/src/duckdb_mcp/__main__.py
+++ b/examples/duckdb-mcp/src/duckdb_mcp/__main__.py
@@ -1,0 +1,3 @@
+from duckdb_mcp import main
+
+main()

--- a/examples/duckdb-mcp/src/duckdb_mcp/server.py
+++ b/examples/duckdb-mcp/src/duckdb_mcp/server.py
@@ -1,0 +1,23 @@
+import duckdb
+from mcp.server.fastmcp import FastMCP
+from mcp.shared.exceptions import McpError
+from mcp.types import ErrorData, INTERNAL_ERROR, INVALID_PARAMS
+
+
+def create_server(db_path: str) -> FastMCP:
+    mcp = FastMCP("duckdb")
+
+    @mcp.tool()
+    def query(sql: str) -> list:
+        """Execute a SQL query using DuckDB and return the results."""
+        try:
+            conn = duckdb.connect(database=db_path)
+            res = conn.execute(sql).fetchall()
+            conn.close()
+            return res
+        except duckdb.Error as e:
+            raise McpError(ErrorData(INVALID_PARAMS, str(e))) from e
+        except Exception as e:  # noqa: BLE001
+            raise McpError(ErrorData(INTERNAL_ERROR, f"Unexpected error: {e}")) from e
+
+    return mcp


### PR DESCRIPTION
## Summary
- add a DuckDB MCP server example
- show how to run the extension via MCP Inspector or CLI

## Testing
- `cargo --version`
- `cargo test --locked --quiet` *(fails: command interrupted)*


------
https://chatgpt.com/codex/tasks/task_e_68433462746883288b92dfcc0cf53374